### PR TITLE
Migrate to Swift 5 and iOS 13

### DIFF
--- a/CoordinatorExample.xcodeproj/project.pbxproj
+++ b/CoordinatorExample.xcodeproj/project.pbxproj
@@ -156,6 +156,7 @@
 			developmentRegion = English;
 			hasScannedForEncodings = 0;
 			knownRegions = (
+				English,
 				en,
 				Base,
 			);
@@ -312,7 +313,7 @@
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = io.townsend.CoordinatorExample;
 				PRODUCT_NAME = "$(TARGET_NAME)";
-				SWIFT_VERSION = 3.0;
+				SWIFT_VERSION = 5.0;
 			};
 			name = Debug;
 		};
@@ -325,7 +326,7 @@
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = io.townsend.CoordinatorExample;
 				PRODUCT_NAME = "$(TARGET_NAME)";
-				SWIFT_VERSION = 3.0;
+				SWIFT_VERSION = 5.0;
 			};
 			name = Release;
 		};
@@ -348,6 +349,7 @@
 				BEEE17D61DD5CB2A004D6FCE /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
 		};
 /* End XCConfigurationList section */
 	};

--- a/CoordinatorExample/AppCoordinator.swift
+++ b/CoordinatorExample/AppCoordinator.swift
@@ -65,6 +65,7 @@ extension AppCoordinator: SplashViewControllerDelegate {
         
         let newOrderCoordinator = NewOrderCoordinator(with: self.services)
         newOrderCoordinator.delegate = self
+        newOrderCoordinator.rootViewController.modalPresentationStyle = .fullScreen
         newOrderCoordinator.start()
         self.addChildCoordinator(newOrderCoordinator)
         self.rootViewController.present(newOrderCoordinator.rootViewController, animated: true, completion: nil)

--- a/CoordinatorExample/AppDelegate.swift
+++ b/CoordinatorExample/AppDelegate.swift
@@ -14,7 +14,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
     var window: UIWindow?
     var appCoordinator: AppCoordinator!
 
-    func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplicationLaunchOptionsKey: Any]?) -> Bool {
+    func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]?) -> Bool {
         
         self.window = UIWindow(frame: UIScreen.main.bounds)
         self.appCoordinator = AppCoordinator(window: self.window!, services: Services())

--- a/CoordinatorExample/Coordinator.swift
+++ b/CoordinatorExample/Coordinator.swift
@@ -14,12 +14,12 @@ public protocol Coordinator: class {
 public extension Coordinator {
     
     /// Add a child coordinator to the parent
-    public func addChildCoordinator(_ childCoordinator: Coordinator) {
+    func addChildCoordinator(_ childCoordinator: Coordinator) {
         self.childCoordinators.append(childCoordinator)
     }
     
     /// Remove a child coordinator from the parent
-    public func removeChildCoordinator(_ childCoordinator: Coordinator) {
+    func removeChildCoordinator(_ childCoordinator: Coordinator) {
         self.childCoordinators = self.childCoordinators.filter { $0 !== childCoordinator }
     }
     

--- a/CoordinatorExample/DrinkTypeViewController.swift
+++ b/CoordinatorExample/DrinkTypeViewController.swift
@@ -58,7 +58,7 @@ public class DrinkTypeViewController: UITableViewController {
         
         let drinkType = self.drinkTypes[indexPath.row]
         
-        let cell = UITableViewCell(style: UITableViewCellStyle.default, reuseIdentifier: nil)
+        let cell = UITableViewCell(style: UITableViewCell.CellStyle.default, reuseIdentifier: nil)
         cell.textLabel?.text = drinkType
         return cell
     }

--- a/CoordinatorExample/SnackTypeViewController.swift
+++ b/CoordinatorExample/SnackTypeViewController.swift
@@ -47,7 +47,7 @@ public class SnackTypeViewController: UITableViewController {
         
         let snackType = self.snackTypes[indexPath.row]
         
-        let cell = UITableViewCell(style: UITableViewCellStyle.default, reuseIdentifier: nil)
+        let cell = UITableViewCell(style: UITableViewCell.CellStyle.default, reuseIdentifier: nil)
         cell.textLabel?.text = snackType
         return cell
     }

--- a/CoordinatorExample/SplashViewController.swift
+++ b/CoordinatorExample/SplashViewController.swift
@@ -31,7 +31,7 @@ public class SplashViewController: UIViewController {
         let newOrderButton = UIButton(type: .system)
         newOrderButton.setTitle("New order", for: .normal)
         newOrderButton.backgroundColor = .red
-        newOrderButton.addTarget(self, action: #selector(didTapNewOrder), for: UIControlEvents.touchUpInside)
+        newOrderButton.addTarget(self, action: #selector(didTapNewOrder), for: UIControl.Event.touchUpInside)
         
         self.view.addSubview(newOrderButton)
         
@@ -71,15 +71,15 @@ public class SplashViewController: UIViewController {
         paragraphStyle.lineSpacing = 20
         
         let fontAttributes = [
-            NSForegroundColorAttributeName: UIColor.black,
-            NSParagraphStyleAttributeName: paragraphStyle,
-            NSFontAttributeName: UIFont.systemFont(ofSize: 40)
+            NSAttributedString.Key.foregroundColor: UIColor.black,
+            NSAttributedString.Key.paragraphStyle: paragraphStyle,
+            NSAttributedString.Key.font: UIFont.systemFont(ofSize: 40)
         ]
         
         let largeFontAttributes = [
-            NSForegroundColorAttributeName: UIColor.black,
-            NSParagraphStyleAttributeName: paragraphStyle,
-            NSFontAttributeName: UIFont.boldSystemFont(ofSize: 70)
+            NSAttributedString.Key.foregroundColor: UIColor.black,
+            NSAttributedString.Key.paragraphStyle: paragraphStyle,
+            NSAttributedString.Key.font: UIFont.boldSystemFont(ofSize: 70)
         ]
         
         let string = NSMutableAttributedString()

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ This is the project to accompany my [blog post on the Coordinator Pattern](https
 
 ## 📍 Getting Started
 
-> As of 11th November 2016, this project requires [Xcode 8.0](https://developer.apple.com/xcode/downloads/) (Swift 3.0)
+> As of 18th of November 2019, this project requires [Xcode 11.0](https://developer.apple.com/xcode/downloads/) (Swift 5.0)
 
 The following commands will download the repository, and open the desired Xcode project.
 


### PR DESCRIPTION
This PR migrates the Xcode project to Swift 5.0, one of two major versions of Swift supported by Xcode 11, and is needed to make the project compile and run if downloaded (fixes #5).

This PR also sets the modal presentation style of the new order coordinator's root controller to `fullScreen` which is needed to trigger `viewWillAppear` of the underlaying splash view controller, which in turn updates the total number of orders. This is because the default modal presentation style changed in iOS 13 to `pageSheet` (fixes #6). 

Finally it updates the readme to accurately reflect the required Xcode and Swift versions